### PR TITLE
Fixes for 02, 04 and 05

### DIFF
--- a/02 GaAs Nanowire - Phase Mapping - Orientation Mapping.ipynb
+++ b/02 GaAs Nanowire - Phase Mapping - Orientation Mapping.ipynb
@@ -302,9 +302,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from diffsims.generators.structure_library_generator import StructureLibraryGenerator\n",
+    "from diffsims.libraries.structure_library import StructureLibrary\n",
     "from diffsims.generators.diffraction_generator import DiffractionGenerator\n",
     "from diffsims.generators.library_generator import DiffractionLibraryGenerator\n",
+    "from diffsims.utils.sim_utils import rotation_list_stereographic\n",
     "\n",
     "from pyxem.generators.indexation_generator import IndexationGenerator"
    ]
@@ -330,18 +331,14 @@
    "outputs": [],
    "source": [
     "structure_zb = diffpy.structure.loadStructure('./GaAs_mp-2534_conventional_standard.cif')\n",
-    "structure_wz = diffpy.structure.loadStructure('./GaAs_mp-8883_conventional_standard.cif')\n",
-    "\n",
-    "phase_descriptions = [('ZB', structure_zb, 'cubic'),\n",
-    "                      ('WZ', structure_wz, 'hexagonal')]\n",
-    "phase_names = [phase[0] for phase in phase_descriptions]"
+    "structure_wz = diffpy.structure.loadStructure('./GaAs_mp-8883_conventional_standard.cif')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Initialize a structure library generator for the specified phases"
+    "Create a basic rotations list.    "
    ]
   },
   {
@@ -350,7 +347,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "struc_lib_gen = StructureLibraryGenerator(phase_descriptions)"
+    "rot_list_cubic = rotation_list_stereographic(structure_zb,(0, 0, 1),(1, 0, 1),(1, 1, 1),np.linspace(0, 2*np.pi, 360/10),np.deg2rad(10))\n",
+    "rot_list_hex   = rotation_list_stereographic(structure_wz,(0, 0, 0, 1), (1, 0, -1, 0), (1, 1, -2, 0),np.linspace(0, 2*np.pi, 360/10),np.deg2rad(10))"
    ]
   },
   {
@@ -366,11 +364,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inplane_rotations = [[0], [0]]  # The library only needs the base in-plane rotation. The other ones are generated\n",
-    "rotation_list_resolution = 1\n",
-    "\n",
-    "struc_lib = struc_lib_gen.get_orientations_from_stereographic_triangle(\n",
-    "                            inplane_rotations, rotation_list_resolution)"
+    "struc_lib = StructureLibrary(['ZB','WZ'],\n",
+    "                             [structure_zb,structure_wz],\n",
+    "                             [rot_list_cubic,rot_list_hex])"
    ]
   },
   {
@@ -450,7 +446,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "diff_lib.pickle_library('./GaAs_cubic_hex_1deg.pickle')"
+    "diff_lib.pickle_library('./GaAs_cubic_hex.pickle')"
    ]
   },
   {
@@ -468,7 +464,7 @@
    "source": [
     "from diffsims.libraries.diffraction_library import load_DiffractionLibrary\n",
     "\n",
-    "diff_lib = load_DiffractionLibrary('./GaAs_cubic_hex_1deg.pickle', safety=True)"
+    "diff_lib = load_DiffractionLibrary('./GaAs_cubic_hex.pickle', safety=True)"
    ]
   },
   {
@@ -948,13 +944,6 @@
    "source": [
     "crystal_map.save_mtex_map('vector_match_results.csv')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/04 Simulate Data - Phase Mapping - Orientation Mapping.ipynb
+++ b/04 Simulate Data - Phase Mapping - Orientation Mapping.ipynb
@@ -72,7 +72,7 @@
     "import diffpy.structure\n",
     "from matplotlib import pyplot as plt\n",
     "\n",
-    "from diffsims.generators.structure_library_generator import StructureLibraryGenerator\n",
+    "from diffsims.utils.sim_utils import rotation_list_stereographic\n",
     "from diffsims.libraries.structure_library import StructureLibrary\n",
     "from diffsims.generators.diffraction_generator import DiffractionGenerator\n",
     "from diffsims.generators.library_generator import DiffractionLibraryGenerator, VectorLibraryGenerator\n",
@@ -222,12 +222,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "structure_library_generator = StructureLibraryGenerator(\n",
-    "    [('Si', si, 'cubic'),\n",
-    "     ('Ga', ga, 'hexagonal')])\n",
-    "structure_library = structure_library_generator.get_orientations_from_stereographic_triangle(\n",
-    "    [(0,), (0,)],  # In-plane rotations\n",
-    "    5)  # Angular resolution of the library"
+    "rot_list_cubic = rotation_list_stereographic(si,(0, 0, 1),(1, 0, 1),(1, 1, 1),np.linspace(0, 2*np.pi, 360/10),np.deg2rad(10))\n",
+    "rot_list_hex   = rotation_list_stereographic(ga,(0, 0, 0, 1), (1, 0, -1, 0), (1, 1, -2, 0),np.linspace(0, 2*np.pi, 50),np.deg2rad(3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "structure_library = StructureLibrary(['si','ga'],\n",
+    "                                    [si,ga],\n",
+    "                                    [rot_list_cubic,rot_list_hex])"
    ]
   },
   {
@@ -255,7 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Correlate with the patterns contained in the library with the test data. At this stage the top 3 (`n_largest`) matching results are retained. Test all in-plane rotations at 5 degree increments from 0 to 360."
+    "Correlate with the patterns contained in the library with the test data. At this stage the top 3 (`n_largest`) matching results are retained."
    ]
   },
   {
@@ -265,7 +272,7 @@
    "outputs": [],
    "source": [
     "indexer = IndexationGenerator(test_data, template_library)\n",
-    "match_results = indexer.correlate(n_largest=3, inplane_rotations=np.arange(0, 360, 5))"
+    "match_results = indexer.correlate(n_largest=3)"
    ]
   },
   {

--- a/05 Simulate Data - Strain Mapping.ipynb
+++ b/05 Simulate Data - Strain Mapping.ipynb
@@ -352,7 +352,7 @@
    "outputs": [],
    "source": [
     "spg = SubpixelrefinementGenerator(dp, np.asarray([x_peak,y_peak]))\n",
-    "Vs = spg.center_of_mass_method(6)"
+    "Vs = spg.center_of_mass_method(30)"
    ]
   },
   {


### PR DESCRIPTION
**02** and **04** are simple changes from the removal of the internal application of `inplane_rotations` in the pattern matching.

**05** is a single value change to make the subpixel peakfinding better.